### PR TITLE
Fix de/serialization of `Option<T>` values

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -415,7 +415,7 @@ where
         };
 
         let element = match field {
-            FieldType::None => return Err(io::Error::from(io::ErrorKind::InvalidData).into()),
+            FieldType::None => return Ok(()),
             FieldType::List(ListElement::Section) => {
                 self.state = State::ListItem(ListElement::Section, None);
                 ElementType::SectionStart
@@ -453,6 +453,7 @@ where
         self.serialize_key(key)?;
 
         match self.state {
+            State::Key(FieldType::None) => return Ok(()),
             State::ListItem(_, _) => {},
             _ => {
                 self.state = State::Value;
@@ -541,7 +542,7 @@ mod tests {
         #[derive(Serialize)]
         struct MainSection {
             #[serde(rename = "sub-section")]
-            sub_section: SubSection,
+            sub_section: Option<SubSection>,
             list1: Vec<String>,
         }
 
@@ -553,9 +554,9 @@ mod tests {
         let data = RootSection {
             key1: "value1".to_string(),
             section1: MainSection {
-                sub_section: SubSection {
+                sub_section: Some(SubSection {
                     key2: "value2".to_string(),
-                },
+                }),
                 list1: vec!["item1".to_string(), "item2".to_string()],
             },
         };
@@ -576,6 +577,58 @@ mod tests {
                 3, 4, b'k', b'e', b'y', b'2', 0, 6, b'v', b'a', b'l', b'u', b'e', b'2',
                 // sub-section end
                 2,
+                // list1
+                4, 5, b'l', b'i', b's', b't', b'1',
+                // item1
+                5, 0, 5, b'i', b't', b'e', b'm', b'1',
+                // item2
+                5, 0, 5, b'i', b't', b'e', b'm', b'2',
+                // list1 end
+                6,
+                // section1 end
+                2,
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_none() {
+        #[derive(Serialize)]
+        struct RootSection {
+            key1: String,
+            section1: MainSection,
+        }
+
+        #[derive(Serialize)]
+        struct MainSection {
+            #[serde(rename = "sub-section")]
+            sub_section: Option<SubSection>,
+            list1: Vec<String>,
+        }
+
+        #[derive(Serialize)]
+        struct SubSection {
+            key2: String,
+        }
+
+        let data = RootSection {
+            key1: "value1".to_string(),
+            section1: MainSection {
+                sub_section: None,
+                list1: vec!["item1".to_string(), "item2".to_string()],
+            },
+        };
+
+        let actual = to_vec(&data).unwrap();
+
+        #[rustfmt::skip]
+        assert_eq!(
+            actual,
+            vec![
+                // key1 = value1
+                3, 4, b'k', b'e', b'y', b'1', 0, 6, b'v', b'a', b'l', b'u', b'e', b'1',
+                // section1
+                1, 8, b's', b'e', b'c', b't', b'i', b'o', b'n', b'1',
                 // list1
                 4, 5, b'l', b'i', b's', b't', b'1',
                 // item1
@@ -699,8 +752,6 @@ mod tests {
                 1, 1, b'3',
                 // address = 192.0.2.5
                 3, 7, b'a', b'd', b'd', b'r', b'e', b's', b's', 0, 9, b'1', b'9', b'2', b'.', b'0', b'.', b'2', b'.', b'5',
-                // identity =
-                3, 8, b'i', b'd', b'e', b'n', b't', b'i', b't', b'y', 0, 0,
                 // status = offline
                 3, 6, b's', b't', b'a', b't', b'u', b's', 0, 7, b'o', b'f', b'f', b'l', b'i', b'n', b'e',
                 // 3 end

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -112,12 +112,15 @@ impl<'a> ser::Serializer for &'a mut FieldTypeSerializer {
 
     #[inline]
     fn serialize_none(self) -> Result<Self::Ok> {
-        Ok(FieldType::String)
+        Ok(FieldType::None)
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok> {
-        Ok(FieldType::String)
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(self)
     }
 
     #[inline]


### PR DESCRIPTION
This PR fixes de/serialization of `Option<T>` values to properly handle the following cases:
* Previously serde-vici serialized `Option<T>` correctly only when it appeared as a string element in [a list](https://github.com/strongswan/strongswan/blob/5.9.11/src/libcharon/plugins/vici/README.md#lists) and otherwise ended up in a broken output. Now it supports serialization of `Option<T>` in other types of elements, i.e. `Option<i32>`, and to [a key/value pair](https://github.com/strongswan/strongswan/blob/5.9.11/src/libcharon/plugins/vici/README.md#keyvalues) and [a section](https://github.com/strongswan/strongswan/blob/5.9.11/src/libcharon/plugins/vici/README.md#sections) as well.
* Previously serde-vici assumed that `Option<T>` only appeared as a string element in [a key/value pair](https://github.com/strongswan/strongswan/blob/5.9.11/src/libcharon/plugins/vici/README.md#keyvalues) and otherwise ended up in an error. Now it supports deserialization to other types of elements, i.e. `Option<i32>`, and [sections](https://github.com/strongswan/strongswan/blob/5.9.11/src/libcharon/plugins/vici/README.md#sections) as well. Note that this has changed the way an empty string is deserialized to `Option<&str>` and the like: previously it was deserialized to `Some("")` but now to `None`.