### PR TITLE
Handle raw binary data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,8 @@ features = ["derive"]
 [dev-dependencies.serde_derive]
 version = "1.0"
 
+[dev-dependencies.serde_bytes]
+version = "0.11"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_vici = "0.1"
 ```
 
+If you want to handle raw binary data in VICI, such as in `list-certs` command, consider using [serde_bytes][].
+
+```toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_vici = "0.1"
+serde_bytes = "0.11"
+```
+
 ## Using Serde VICI
 
 For example, serializing/deserializing the [Encoding Example][] looks like the
@@ -92,6 +101,30 @@ fn main() -> Result<(), serde_vici::Error> {
 }
 ```
 
+## Using Serde VICI With Raw Bytes
+
+For example, deserializing raw bytes into `Vec<u8>`, which otherwise will be treated as sequence.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CertResponse {
+    #[serde(rename = "type")]
+    tpe: String,
+    flat: String,
+    has_privkey: bool,
+
+    #[serde(with = "serde_bytes")]
+    data: Vec<u8>,
+    
+    subject: String,
+    not_before: String,
+    not_after: String,
+}
+```
+
 [workflow-link]:    https://github.com/chitoku-k/serde-vici/actions?query=branch:master
 [workflow-badge]:   https://img.shields.io/github/actions/workflow/status/chitoku-k/serde-vici/ci.yml?branch=master&style=flat-square&logo=github
 [docsrs-link]:      https://docs.rs/serde_vici/
@@ -100,4 +133,5 @@ fn main() -> Result<(), serde_vici::Error> {
 [cratesio-badge]:   https://img.shields.io/crates/v/serde_vici?style=flat-square
 [Serde]:            https://github.com/serde-rs/serde
 [VICI]:             https://github.com/strongswan/strongswan/blob/5.9.5/src/libcharon/plugins/vici/README.md
+[serde_bytes]:      https://github.com/serde-rs/bytes
 [Encoding Example]: https://github.com/strongswan/strongswan/blob/5.9.5/src/libcharon/plugins/vici/README.md#encoding-example

--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct CertResponse {
-    #[serde(rename = "type")]
-    tpe: String,
-    flat: String,
+    r#type: String,
+    flag: String,
     has_privkey: bool,
 
     #[serde(with = "serde_bytes")]

--- a/src/de.rs
+++ b/src/de.rs
@@ -746,15 +746,18 @@ mod tests {
             X509Crl,
             #[serde(rename = "OCSP_RESPONSE")]
             OcspResponse,
-            PUBKEY,
+            #[serde(rename = "PUBKEY")]
+            Pubkey,
         }
 
         #[derive(Debug, Deserialize, Eq, PartialEq)]
         enum Flag {
-            NONE,
+            #[serde(rename = "NONE")]
+            None,
             CA,
             AA,
-            OCSP
+            #[serde(rename = "OCSP")]
+            Ocsp
         }
 
         #[derive(Debug, Deserialize, Eq, PartialEq)]
@@ -1028,15 +1031,18 @@ mod tests {
             X509Crl,
             #[serde(rename = "OCSP_RESPONSE")]
             OcspResponse,
-            PUBKEY,
+            #[serde(rename = "PUBKEY")]
+            Pubkey,
         }
 
         #[derive(Debug, Deserialize, Eq, PartialEq)]
         enum Flag {
-            NONE,
+            #[serde(rename = "NONE")]
+            None,
             CA,
             AA,
-            OCSP
+            #[serde(rename = "OCSP")]
+            Ocsp
         }
 
         #[derive(Debug, Deserialize, Eq, PartialEq)]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -763,4 +763,58 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn serialize_certs() {
+        #[allow(dead_code)]
+        #[derive(Serialize)]
+        enum Type {
+            X509,
+            #[serde(rename = "X509_AC")]
+            X509Ac,
+            #[serde(rename = "X509_CRL")]
+            X509Crl,
+            #[serde(rename = "OCSP_RESPONSE")]
+            OcspResponse,
+            PUBKEY,
+        }
+
+        #[allow(dead_code)]
+        #[derive(Serialize)]
+        enum Flag {
+            NONE,
+            CA,
+            AA,
+            OCSP
+        }
+
+        #[derive(Serialize)]
+        struct CertResponse {
+            r#type: Type,
+            flag: Flag,
+            #[serde(with = "serde_bytes")]
+            data: Vec<u8>,
+        }
+
+        let data = CertResponse {
+            r#type: Type::X509,
+            flag: Flag::CA,
+            data: vec![0x00, 0x01, 0x02, 0x03],
+        };
+
+        let actual = to_vec(&data).unwrap();
+
+        #[rustfmt::skip]
+        assert_eq!(
+            actual,
+            vec![
+                // type = X509
+                3, 4, b't', b'y', b'p', b'e', 0, 4, b'X', b'5', b'0', b'9',
+                // flag = CA
+                3, 4, b'f', b'l', b'a', b'g', 0, 2, b'C', b'A',
+                // data = 0x00 0x01 0x02 0x03
+                3, 4, b'd', b'a', b't', b'a', 0, 4, 0x00, 0x01, 0x02, 0x03,
+            ]
+        );
+    }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -776,16 +776,19 @@ mod tests {
             X509Crl,
             #[serde(rename = "OCSP_RESPONSE")]
             OcspResponse,
-            PUBKEY,
+            #[serde(rename = "PUBKEY")]
+            Pubkey,
         }
 
         #[allow(dead_code)]
         #[derive(Serialize)]
         enum Flag {
-            NONE,
+            #[serde(rename = "NONE")]
+            None,
             CA,
             AA,
-            OCSP
+            #[serde(rename = "OCSP")]
+            Ocsp
         }
 
         #[derive(Serialize)]


### PR DESCRIPTION
This PR adds raw binary data handling.

Previously, all values in key-value pairs were presumed to be `utf-8` encoded byte sequences and hence decoding was attempted on. This caused panic when random blobs were coming from VICI.

The feature of consuming raw bytes as-is and using them in `deserialize_bytes` as well as `deserialize_byte_buf` is added. Also, in case of `deserialize_any`, values are consumed as-is for safe operation. The user can later decode them if required.

This PR is related to #15 